### PR TITLE
Remember the atomic number after the first time it was set.

### DIFF
--- a/chemistry/amber/_amberparm.py
+++ b/chemistry/amber/_amberparm.py
@@ -406,8 +406,10 @@ class AmberParm(AmberFormat, Structure):
             screen = zeros
         try:
             atnum = self.parm_data['ATOMIC_NUMBER']
+            replace_atnum = True
         except KeyError:
             atnum = [AtomicNum[element_by_mass(m)] for m in mass]
+            replace_atnum = False
         try:
             occu = self.parm_data['ATOM_OCCUPANCY']
         except KeyError:
@@ -431,7 +433,8 @@ class AmberParm(AmberFormat, Structure):
             atom.tree = tree[i]
             atom.radii = radii[i]
             atom.screen = screen[i]
-            atom.atomic_number = atnum[i]
+            if replace_atnum or atom.atomic_number == 0:
+                atom.atomic_number = atnum[i]
             atom.atom_type = AtomType(atyp[i], None, mass[i], atnum[i])
             atom.occupancy = occu[i]
             atom.bfactor = bfac[i]


### PR DESCRIPTION
This fixes issues in which someone may change some atomic masses and those
atomic numbers will be reset to strange values if ATOMIC_NUMBER is not set in
the topology file.  This change makes it so the atomic number will be set at the
beginning of the Python program and not change (unless requested to) for the
rest of the script.