### PR TITLE
Do filename globbing in the chamber action.

### DIFF
--- a/ParmedTools/ParmedActions.py
+++ b/ParmedTools/ParmedActions.py
@@ -3218,12 +3218,17 @@ class chamber(Action):
     the order they are specified), followed by all parameter files, and finally
     all stream files are read in.  Topology files are only necessary if the
     parameter files do not define the atom types (newer CHARMM force fields
-    define atom types directly in the parameter file.
+    define atom types directly in the parameter file. Environment variables and
+    shell wild-cards (* and ?), as well as the home shortcut character ~ are
+    properly expanded when looking for files.
 
     Options:
         -top        CHARMM topology, or Residue Topology File (RTF) file
         -param      CHARMM parameter file
         -str        CHARMM stream file. Only RTF and parameter sections are read
+        -toppar     CHARMM topology, parameter, and/or stream file(s). File type
+                    is detected from extension (or in the case of .inp files,
+                    the presence of 'top', 'par' in the name)
         -psf        CHARMM PSF file
         -crd        Input coordinate file (PDB, CHARMM CRD, or CHARMM restart)
         -nocmap     Do not use any CMAP parameters
@@ -3244,35 +3249,67 @@ class chamber(Action):
 
     def init(self, arg_list):
         from os.path import expandvars, expanduser
+        import glob
         # First get all of the topology files
         self.topfiles, self.paramfiles, self.streamfiles = [], [], []
         while arg_list.has_key('-top', mark=False):
             topfile = expanduser(arg_list.get_key_string('-top', None))
             topfile = expandvars(topfile)
-            if not os.path.exists(topfile):
+            topfiles = glob.glob(topfile)
+            if not topfiles:
                 raise FileDoesNotExist('CHARMM RTF file %s does not exist' %
                                        topfile)
-            self.topfiles.append(topfile)
+            self.topfiles.extend(topfiles)
         while arg_list.has_key('-param', mark=False):
             param = expanduser(arg_list.get_key_string('-param', None))
             param = expandvars(param)
-            if not os.path.exists(param):
+            params = glob.glob(param)
+            if not params:
                 raise FileDoesNotExist('CHARMM parameter file %s does not exist'
                                        % param)
-            self.paramfiles.append(param)
+            self.paramfiles.extend(params)
         while arg_list.has_key('-str', mark=False):
             stream = expanduser(arg_list.get_key_string('-str', None))
             stream = expandvars(stream)
-            if not os.path.exists(stream):
+            streams = glob.glob(stream)
+            if not streams:
                 raise FileDoesNotExist('CHARMM stream file %s does not exist' %
                                        stream)
-            self.streamfiles.append(stream)
+            self.streamfiles.extend(streams)
+        while arg_list.has_key('-toppar', mark=False):
+            toppar = expanduser(arg_list.get_key_string('-toppar', None))
+            toppar = expandvars(toppar)
+            toppars = glob.glob(toppar)
+            if not toppars:
+                raise FileDoesNotExist('CHARMM toppar file %s does not exist' %
+                                       toppar)
+            for fname in toppars:
+                base = os.path.split(fname)[1] # ignore the directory name
+                if base.endswith('.rtf') or base.endswith('.top'):
+                    self.topfiles.append(fname)
+                elif base.endswith('.par') or base.endswith('.prm'):
+                    self.paramfiles.append(fname)
+                elif base.endswith('.str'):
+                    self.streamfiles.append(fname)
+                elif base.endswith('.inp'):
+                    if 'par' in fname:
+                        self.paramfiles.append(fname)
+                    elif 'top' in fname:
+                        self.topfiles.append(fname)
+                    else:
+                        raise InputError('Cannot detect filetype of %s' % fname)
+                else:
+                    raise InputError('Cannot detect filetype of %s' % fname)
         crdfile = arg_list.get_key_string('-crd', None)
         if crdfile is not None:
-            self.crdfile = expanduser(expandvars(crdfile))
-            if not os.path.exists(self.crdfile):
+            crdfiles = glob.glob(expanduser(expandvars(crdfile)))
+            if not crdfiles:
                 raise FileDoesNotExist('Coordinate file %s does not exist' %
                                        self.crdfile)
+            if len(crdfiles) > 1:
+                raise InputError('Too many coordinate files selected through '
+                                 'globbing')
+            self.crdfile = crdfiles[0]
         else:
             self.crdfile = None
         self.cmap = not arg_list.has_key('-nocmap')
@@ -3280,9 +3317,12 @@ class chamber(Action):
         psf = arg_list.get_key_string('-psf', None)
         if psf is None:
             raise InputError('chamber requires a PSF file')
-        self.psf = expanduser(expandvars(psf))
-        if not os.path.exists(self.psf):
-            raise InputError('chamber PSF file %s cannot be found' % self.psf)
+        self.psf = glob.glob(expanduser(expandvars(psf)))
+        if not self.psf:
+            raise FileDoesNotExist('chamber PSF file %s cannot be found' % psf)
+        if len(self.psf) > 1:
+            raise InputError('Too many PSF files selected through globbing')
+        self.psf = self.psf[0]
         box = arg_list.get_key_string('-box', None)
 
         if box is None:

--- a/test/test_parmedtools_actions.py
+++ b/test/test_parmedtools_actions.py
@@ -76,8 +76,25 @@ class TestNonParmActions(unittest.TestCase):
         self.assertTrue(parm.has_cmap)
         self.assertEqual(parm.ptr('ifbox'), 0)
 
+    def testChamberGlobbing(self):
+        """ Test globbing in the chamber action """
+        warnings.filterwarnings('ignore', category=CharmmPSFWarning,
+                                module='psf')
+        a = PT.chamber(self.parm, '-psf', get_fn('ala_ala_ala.psf'),
+                       '-toppar', get_fn('*_all22_prot.inp'),
+                       '-crd', get_fn('ala_ala_ala.pdb'))
+        a.execute()
+        parm = a.parm
+        self._standard_parm_tests(parm)
+        self._extensive_checks(parm)
+        self.assertTrue(parm.chamber)
+        self.assertTrue(parm.has_cmap)
+        self.assertEqual(parm.ptr('ifbox'), 0)
+
     def testChamberNbfix(self):
         """ Test the chamber action with a complex system using NBFIX """
+        warnings.filterwarnings('ignore', category=CharmmPSFWarning,
+                                module='psf')
         a = PT.chamber(self.parm, '-psf %s' % get_fn('ala3_solv.psf'),
                        '-param %s' % get_fn('par_all36_prot.prm'),
                        '-str %s' % get_fn('toppar_water_ions.str'),


### PR DESCRIPTION
Also add a -toppar flag so that 'chamber' will try to determine what the file
type of each file is based on extension (or the presence of 'top' or 'par' in
the case that the extension is '.inp'). This should make input simpler.

Add a test for the new globbing functionality.