### PR TITLE
Load the coordinates into the generated PSF file before converting it to a prmtop

### DIFF
--- a/ParmedTools/ParmedActions.py
+++ b/ParmedTools/ParmedActions.py
@@ -3461,6 +3461,11 @@ class chamber(Action):
                 raise ChamberError('Mismatch in number of coordinates (%d) and '
                                    '3*number of atoms (%d)' % (len(coords),
                                    3*len(psf.atoms)))
+            # Set the coordinates now, since creating the parm may re-order the
+            # atoms in order to maintain contiguous molecules
+            for i, atom in enumerate(psf.atoms):
+                i3 = i * 3
+                atom.xx, atom.xy, atom.xz = coords[i3:i3+3]
             # Set the box info from self.box if set
             if self.box is None and crdbox is not None:
                 psf.set_box(*crdbox[:])
@@ -3505,8 +3510,6 @@ class chamber(Action):
         except ChemError, e:
             raise ChamberError('Problem assigning parameters to PSF: %s' % e)
         parm = ConvertFromPSF(psf, parmset).view(ChamberParm)
-        if self.crdfile is not None:
-            parm.load_coordinates(coords)
         parm.prm_name = self.psf
         changeradii(parm, self.radii).execute()
         self.parm_list.add_parm(parm)

--- a/chemistry/amber/_amberparm.py
+++ b/chemistry/amber/_amberparm.py
@@ -229,10 +229,10 @@ class AmberParm(AmberFormat, Structure):
         inst.initialize_topology()
         # See if the rawdata has any kind of structural attributes, like
         # coordinates and an atom list with positions and/or velocities
-        if hasattr(rawdata, 'coords'):
-            inst.coords = copy.copy(rawdata.coords)
-        if hasattr(rawdata, 'vels'):
-            inst.vels = copy.copy(rawdata.vels)
+        if hasattr(rawdata, 'coords') and rawdata.coords is not None:
+            inst.load_coordinates(copy.copy(rawdata.coords))
+        if hasattr(rawdata, 'vels') and rawdata.vels is not None:
+            inst.load_velocities(copy.copy(rawdata.vels))
         if hasattr(rawdata, 'box'):
             inst.box = copy.copy(rawdata.box)
         if hasattr(rawdata, 'hasbox'):
@@ -283,6 +283,14 @@ class AmberParm(AmberFormat, Structure):
             inst.parm_data['POINTERS'][IFBOX] = 1
             inst.pointers['IFBOX'] = 1
             inst.parm_data['BOX_DIMENSIONS'] = [struct.box[3]] + struct.box[:3]
+        try:
+            coords = []
+            for atom in struct.atoms:
+                coords.extend([atom.xx, atom.xy, atom.xz])
+        except AttributeError:
+            raise
+        else:
+            inst.load_coordinates(coords)
         inst.remake_parm()
         inst._set_nonbonded_tables()
 

--- a/chemistry/amber/_chamberparm.py
+++ b/chemistry/amber/_chamberparm.py
@@ -651,6 +651,16 @@ def ConvertFromPSF(struct, params, title=''):
         fftype.extend([len(params.parametersets), pset])
     if not fftype:
         fftype.extend([1, 'CHARMM force field: No FF information parsed...'])
+    # Set the coords attribute if applicable
+    try:
+        coords = []
+        for atom in parm.atoms:
+            coords.extend([atom.xx, atom.xy, atom.xz])
+    except AttributeError:
+        # No coordinates... that's OK
+        pass
+    else:
+        parm.coords = coords
     # Convert atom types back to integers if that's how they started
     if int_starting:
         for atom in struct.atoms:

--- a/chemistry/amber/_chamberparm.py
+++ b/chemistry/amber/_chamberparm.py
@@ -185,6 +185,14 @@ class ChamberParm(AmberParm):
             inst.parm_data['POINTERS'][IFBOX] = 1
             inst.pointers['IFBOX'] = 1
             inst.parm_data['BOX_DIMENSIONS'] = [struct.box[3]] + struct.box[:3]
+        try:
+            coords = []
+            for atom in struct.atoms:
+                coords.extend([atom.xx, atom.xy, atom.xz])
+        except AttributeError:
+            raise
+        else:
+            inst.load_coordinates(coords)
         inst.remake_parm()
         inst._set_nonbonded_tables(nbfixes)
 
@@ -651,16 +659,7 @@ def ConvertFromPSF(struct, params, title=''):
         fftype.extend([len(params.parametersets), pset])
     if not fftype:
         fftype.extend([1, 'CHARMM force field: No FF information parsed...'])
-    # Set the coords attribute if applicable
-    try:
-        coords = []
-        for atom in parm.atoms:
-            coords.extend([atom.xx, atom.xy, atom.xz])
-    except AttributeError:
-        # No coordinates... that's OK
-        pass
-    else:
-        parm.coords = coords
+
     # Convert atom types back to integers if that's how they started
     if int_starting:
         for atom in struct.atoms:


### PR DESCRIPTION
In case atoms need to be re-ordered by ParmEd.

This fixes a bug where coordinates were assigned incorrectly if the PSF file had
non-contiguous molecules following the CHAMBER action.