### PR TITLE
CHARMM PDB file support

### DIFF
--- a/chemistry/charmm/psf.py
+++ b/chemistry/charmm/psf.py
@@ -213,7 +213,7 @@ class CharmmPsfFile(Structure):
             atid = int(words[0])
             if atid != i + 1:
                 raise CharmmPSFError('Nonsequential atoms detected!')
-            system = words[1]
+            segid = words[1]
             resid = conv(words[2], int, 'residue number')
             resname = words[3]
             name = words[4]
@@ -227,8 +227,9 @@ class CharmmPsfFile(Structure):
             mass = conv(words[7], float, 'atomic mass')
             props = words[8:]
             atom = Atom(name=name, type=attype, charge=charge, mass=mass)
+            atom.segid = segid
             atom.props = props
-            self.residues.add_atom(atom, resname, resid, chain=system)
+            self.residues.add_atom(atom, resname, resid)
             self.atoms.append(atom)
         # Now get the number of bonds
         nbond = conv(psfsections['NBOND'][0], int, 'number of bonds')

--- a/chemistry/charmm/psf.py
+++ b/chemistry/charmm/psf.py
@@ -401,7 +401,11 @@ class CharmmPsfFile(Structure):
                 fmt = atmfmt2
             else:
                 fmt = atmfmt1
-            atmstr = fmt % (i+1, atom.residue.chain, atom.residue.number,
+            if hasattr(atom, 'segid'):
+                segid = atom.segid
+            else:
+                segid = 'SYS'
+            atmstr = fmt % (i+1, segid, atom.residue.number,
                             atom.residue.name, atom.name, atom.type,
                             atom.charge, atom.mass)
             if hasattr(atom, 'props'):

--- a/chemistry/structure.py
+++ b/chemistry/structure.py
@@ -519,7 +519,7 @@ class Structure(object):
     #===================================================
 
     def write_pdb(self, dest, renumber=True, coordinates=None,
-                  altlocs='all', write_anisou=False):
+                  altlocs='all', write_anisou=False, charmm=False):
         """
         Write a PDB file from the current Structure instance
 
@@ -554,6 +554,10 @@ class Structure(object):
         write_anisou : bool=False
             If True, an ANISOU record is written for every atom that has one. If
             False, ANISOU records are not written
+        charmm : bool=False
+            If True, SEGID will be written in columns 73 to 76 of the PDB file
+            in the typical CHARMM-style PDB output. This will be omitted for any
+            atom that does not contain a SEGID identifier.
         """
         if altlocs.lower() == 'all'[:len(altlocs)]:
             altlocs = 'all'
@@ -574,7 +578,7 @@ class Structure(object):
                 dest = open(dest, 'w')
             own_handle = True
         atomrec = ('ATOM  %5d %-4s%1s%-3s %1s%4d%1s   %8.3f%8.3f%8.3f%6.2f'
-                   '%6.2f          %2s%-2s\n')
+                   '%6.2f      %-4s%2s%-2s\n')
         anisourec = ('ANISOU%5d %-4s%1s%-3s %1s%4d%1s %7d%7d%7d%7d%7d%7d'
                      '      %2s%-2s\n')
         terrec = ('TER   %5d      %-3s %1s%4d\n')
@@ -639,21 +643,27 @@ class Structure(object):
                 pa, others, (x, y, z) = print_atoms(atom, coords)
                 # Figure out the serial numbers we want to print
                 if renumber:
-                    anum = (atom.idx + 1 + nmore) % 100000
-                    rnum = (res.idx + 1) % 10000
+                    anum = (atom.idx + 1 + nmore)
+                    rnum = (res.idx + 1)
                 else:
-                    anum = (pa.number or last_number + 1) % 100000
-                    rnum = (atom.residue.number or last_rnumber + 1) % 10000
-                    last_number = anum
-                    last_rnumber = rnum
+                    anum = (pa.number or last_number + 1)
+                    rnum = (atom.residue.number or last_rnumber + 1)
+                anum = anum - anum // 100000 * 100000
+                rnum = rnum - rnum // 10000 * 10000
+                last_number = anum
+                last_rnumber = rnum
                 # Do any necessary name munging to respect the PDB spec
                 if len(pa.name) < 4 and len(Element[pa.atomic_number]) != 2:
                     aname = ' %-3s' % pa.name
                 else:
                     aname = pa.name[:4]
+                if charmm and hasattr(pa, 'segid'):
+                    segid = pa.segid
+                else:
+                    segid = ''
                 dest.write(atomrec % (anum , aname, pa.altloc,
                            res.name, res.chain, rnum, res.insertion_code,
-                           x, y, z, pa.occupancy, pa.bfactor,
+                           x, y, z, pa.occupancy, pa.bfactor, segid,
                            Element[pa.atomic_number].upper(), ''))
                 if write_anisou and pa.anisou is not None:
                     anisou = [int(x*1e4) for x in pa.anisou]
@@ -667,18 +677,23 @@ class Structure(object):
                     x, y, z = oatom.xx, oatom.xy, oatom.xz
                     if renumber:
                         nmore += 1
-                        anum = (pa.idx + 1 + nmore) % 100000
+                        anum = (pa.idx + 1 + nmore)
                     else:
                         anum = oatom.number or last_number + 1
-                        last_number = anum
+                    anum = anum - anum // 100000 * 100000
+                    last_number = anum
                     if (len(oatom.name) < 4 and
                             len(Element[oatom.atomic_number]) != 2):
                         aname = ' %-3s' % oatom.name
                     else:
                         aname = oatom.name[:4]
+                    if charmm and hasattr(oatom, 'segid'):
+                        segid = oatom.segid
+                    else:
+                        segid = ''
                     dest.write(atomrec % (anum, aname, key, res.name,
                                res.chain, rnum, res.insertion_code, x, y,
-                               z, oatom.occupancy, oatom.bfactor,
+                               z, oatom.occupancy, oatom.bfactor, segid,
                                Element[oatom.atomic_number].upper(), ''))
                     if write_anisou and oatom.anisou is not None:
                         anisou = [int(x*1e4) for x in oatom.anisou]
@@ -994,6 +1009,7 @@ def read_PDB(filename):
                 x, y, z = line[30:38], line[38:46], line[47:54]
                 occupancy, bfactor = line[54:60], line[60:66]
                 elem, chg = line[76:78], line[78:80]
+                segid = line[72:76].strip() # CHARMM-specific
                 atname = atname.strip()
                 altloc = altloc.strip()
                 resname = resname.strip()
@@ -1108,6 +1124,7 @@ def read_PDB(filename):
                             charge=chg, mass=mass, occupancy=occupancy,
                             bfactor=bfactor, altloc=altloc, number=atnum)
                 atom.xx, atom.xy, atom.xz = float(x), float(y), float(z)
+                if segid: atom.segid = segid
                 if _compare_atoms(last_atom, atom, resname, resid, chain):
                     atom.residue = last_atom.residue
                     last_atom.other_locations[altloc] = atom

--- a/chemistry/structure.py
+++ b/chemistry/structure.py
@@ -658,18 +658,19 @@ class Structure(object):
                 else:
                     aname = pa.name[:4]
                 if charmm and hasattr(pa, 'segid'):
-                    segid = pa.segid
+                    segid = pa.segid[:4]
                 else:
                     segid = ''
                 dest.write(atomrec % (anum , aname, pa.altloc,
-                           res.name, res.chain, rnum, res.insertion_code,
-                           x, y, z, pa.occupancy, pa.bfactor, segid,
+                           res.name[:3], res.chain[:1], rnum,
+                           res.insertion_code[:1], x, y, z, pa.occupancy,
+                           pa.bfactor, segid,
                            Element[pa.atomic_number].upper(), ''))
                 if write_anisou and pa.anisou is not None:
                     anisou = [int(x*1e4) for x in pa.anisou]
                     dest.write(anisourec % (anum, aname, pa.altloc,
-                               res.name, res.chain, rnum,
-                               res.insertion_code, anisou[0], anisou[1],
+                               res.name[:3], res.chain[:1], rnum,
+                               res.insertion_code[:1], anisou[0], anisou[1],
                                anisou[2], anisou[3], anisou[4], anisou[5],
                                Element[pa.atomic_number].upper(), ''))
                 for key in sorted(others.keys()):
@@ -688,18 +689,18 @@ class Structure(object):
                     else:
                         aname = oatom.name[:4]
                     if charmm and hasattr(oatom, 'segid'):
-                        segid = oatom.segid
+                        segid = oatom.segid[:4]
                     else:
                         segid = ''
                     dest.write(atomrec % (anum, aname, key, res.name,
-                               res.chain, rnum, res.insertion_code, x, y,
-                               z, oatom.occupancy, oatom.bfactor, segid,
+                               res.chain[:1], rnum, res.insertion_code[:1],
+                               x, y, z, oatom.occupancy, oatom.bfactor, segid,
                                Element[oatom.atomic_number].upper(), ''))
                     if write_anisou and oatom.anisou is not None:
                         anisou = [int(x*1e4) for x in oatom.anisou]
                         dest.write(anisourec % (anum, aname,
-                            oatom.altloc, res.name, res.chain, rnum,
-                            res.insertion_code, anisou[0], anisou[1],
+                            oatom.altloc[:1], res.name[:3], res.chain[:1], rnum,
+                            res.insertion_code[:1], anisou[0], anisou[1],
                             anisou[2], anisou[3], anisou[4], anisou[5],
                             Element[oatom.atomic_number].upper(), ''))
             if res.ter:
@@ -1287,7 +1288,7 @@ def read_PDB(filename):
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 def write_PDB(struct, dest, renumber=True, coordinates=None, altlocs='all',
-              write_anisou=False):
+              write_anisou=False, charmm=False):
     """
     Write a PDB file from a structure instance
 
@@ -1322,7 +1323,11 @@ def write_PDB(struct, dest, renumber=True, coordinates=None, altlocs='all',
     write_anisou : bool=False
         If True, an ANISOU record is written for every atom that has one. If
         False, ANISOU records are not written
+    charmm : bool=False
+        If True, SEGID will be written in columns 73 to 76 of the PDB file in
+        the typical CHARMM-style PDB output. This will be omitted for any atom
+        that does not contain a SEGID identifier.
     """
-    struct.write_pdb(dest, renumber, coordinates, altlocs, write_anisou)
+    struct.write_pdb(dest, renumber, coordinates, altlocs, write_anisou, charmm)
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/chemistry/topologyobjects.py
+++ b/chemistry/topologyobjects.py
@@ -360,6 +360,10 @@ class Atom(_ListItem):
     vdw_weight : float
         In the AMOEBA force field, this is the weight of the van der Waals
         interaction on the parent atom
+    segid : str
+        In CHARMM PDB and PSF files, the SEGID behaves similarly to the residue
+        chain ID and is used to separate the total system into representative
+        parts. This will only be set if read in from the input structure.
 
     Notes
     -----

--- a/test/test_chemistry_charmm.py
+++ b/test/test_chemistry_charmm.py
@@ -91,7 +91,7 @@ class TestCharmmPsf(unittest.TestCase):
         self.assertEqual(len(a.name), 1)
         self.assertEqual(len(a.props), 3)
         self.assertEqual(len(a.residue), 12)
-        self.assertEqual(len(a.residue.chain), 3)
+        self.assertEqual(len(a.segid), 3)
         self.assertEqual(len(a.urey_bradleys), 0)
         # Check attributes of the psf file
         self.assertEqual(len(cpsf.acceptors), 4)
@@ -168,7 +168,7 @@ class TestCharmmPsf(unittest.TestCase):
         self.assertEqual(len(a.name), 1)
         self.assertEqual(len(a.props), 3)
         self.assertEqual(len(a.residue), 12)
-        self.assertEqual(len(a.residue.chain), 3)
+        self.assertEqual(len(a.segid), 3)
         self.assertEqual(len(a.urey_bradleys), 0)
         # Check attributes of the psf file
         self.assertEqual(len(cpsf.acceptors), 4)
@@ -261,7 +261,7 @@ class TestCharmmPsf(unittest.TestCase):
         self.assertEqual(len(a.name), 1)
         self.assertEqual(len(a.props), 1)
         self.assertEqual(len(a.residue), 12)
-        self.assertEqual(len(a.residue.chain), 2)
+        self.assertEqual(len(a.segid), 2)
         self.assertEqual(len(a.urey_bradleys), 0)
         # Check attributes of the psf file
         self.assertEqual(len(cpsf.acceptors), 0)


### PR DESCRIPTION
This adds support for reading (and optionally writing) a SEGID written in columns 73 to 76 (inclusive) in the PDB file. The standard makes no specification for these columns, so we can assign those columns to be a "segid" while still supporting fully compliant PDB files.

Also provide a "`charmm` keyword for `Structure.write_pdb` and `structure.write_PDB` (that defaults to `False`) that will optionally print out the SEGID in columns 73 through 76 (left-justified).

Finally, this changes the `system` string that the `CharmmPsfFile` parsed into this segid so that PSF -> PDB will be more in line with what CHARMM users expect (assuming they use `charmm=True` when writing a PDB file).

Unrelated changes include truncating a bunch of strings in the PDB writing routine to make sure they do not overflow their allotted columns.