### PR TITLE
Fix problem identifying GROMACS version 5

### DIFF
--- a/GmxTests/test.py
+++ b/GmxTests/test.py
@@ -34,12 +34,12 @@ import simtk.openmm.app as app
 
 # Gromacs settings
 gmxsuffix=""
-if which('mdrun'+gmxsuffix) != '':
-    gmxpath = which('mdrun'+gmxsuffix)
-    GMXVERSION = 4
-elif which('gmx'+gmxsuffix) != '':
+if which('gmx'+gmxsuffix) != '':
     gmxpath = which('gmx'+gmxsuffix)
     GMXVERSION = 5
+elif which('mdrun'+gmxsuffix) != '':
+    gmxpath = which('mdrun'+gmxsuffix)
+    GMXVERSION = 4
 else:
     logger.error("Cannot find the GROMACS executables!\n")
     raise RuntimeError


### PR DESCRIPTION
Both version 5 and version 4 use `mdrun` as the name of the executable. Version 5 is distinguished by having `gmx` whereas version 4 does not. Switched order of 'if' statements to catch this.
