### PR TITLE
Force virtual site atom type names to pass sander test_numextra

### DIFF
--- a/chemistry/amber/_amberparm.py
+++ b/chemistry/amber/_amberparm.py
@@ -1442,8 +1442,8 @@ class AmberParm(AmberFormat, Structure):
         if 'ATOMIC_NUMBER' in data:
             data['ATOMIC_NUMBER'] = [atom.atomic_number for atom in self.atoms]
             for iatom, atom in enumerate(self.atoms):
-                 if atom.atomic_number == 0:
-                     data['AMBER_ATOM_TYPE'][iatom] = 'EP'
+                if atom.atomic_number == 0:
+                    data['AMBER_ATOM_TYPE'][iatom] = 'EP'
         # Do the non-bonded exclusions now
         data['EXCLUDED_ATOMS_LIST'] = []
         nextra = 0

--- a/chemistry/amber/_amberparm.py
+++ b/chemistry/amber/_amberparm.py
@@ -1441,6 +1441,9 @@ class AmberParm(AmberFormat, Structure):
             data['SCREEN'] = [atom.screen for atom in self.atoms]
         if 'ATOMIC_NUMBER' in data:
             data['ATOMIC_NUMBER'] = [atom.atomic_number for atom in self.atoms]
+            for iatom, atom in enumerate(self.atoms):
+                 if atom.atomic_number == 0:
+                     data['AMBER_ATOM_TYPE'][iatom] = 'EP'
         # Do the non-bonded exclusions now
         data['EXCLUDED_ATOMS_LIST'] = []
         nextra = 0


### PR DESCRIPTION
sander was having trouble reading my output prmtop file; I found this was because `AMBER_ATOM_TYPE` was set to `MW` for a TIP4P water molecule, and sander counts the number of virtual sites by atom types matching `EP`.  This can be fixed by setting all virtual site `AMBER_ATOM_TYPEs` to `EP`, but I'm not sure how to do this best.
