### PR TITLE
writing NUMLP section into psf file

### DIFF
--- a/parmed/charmm/psf.py
+++ b/parmed/charmm/psf.py
@@ -317,9 +317,16 @@ class CharmmPsfFile(Structure):
             # Assign all of the atoms to molecules recursively
             tmp = psfsections['MOLNT'][1]
             tag_molecules(self)
-            if len(tmp) == len(self.atoms):
+            self.groups.numlp = None
+            if len(psfsections["NUMLP NUMLPH"][1]) != 0:
                 # We have a CHARMM PSF file; now do NUMLP/NUMLPH sections
                 self._process_lonepair_section(psfsections["NUMLP NUMLPH"])
+                self.groups.numlp = [
+                    psfsections["NUMLP NUMLPH"][0][0],
+                    psfsections["NUMLP NUMLPH"][0][1],
+                ]  # NUMLP is the number of lp and NUMLPH is the number of lp hosts
+            else:
+                pass
             # Now process the NUMANISO records if this is a drude PSF
             if is_drude:
                 self._process_aniso_section(psfsections["NUMANISO"])

--- a/parmed/formats/psf.py
+++ b/parmed/formats/psf.py
@@ -267,8 +267,42 @@ class PSFFile(metaclass=FileFormatType):
             if len(struct.atoms) % 8 != 0: dest.write('\n')
             dest.write('\n')
             # NUMLP/NUMLPH section
-            dest.write((intfmt*2) % (0, 0) + ' !NUMLP NUMLPH\n')
-            dest.write('\n')
+            # if struct.groups.numlp != None:
+            if hasattr(struct.groups, 'numlp') and struct.groups.numlp != None:
+                dest.write(
+                    (intfmt * 2) % (struct.groups.numlp[0], struct.groups.numlp[1])
+                    + " !NUMLP NUMLPH\n"
+                )
+                last_line = ""
+                i = 1
+                for pos, atom in enumerate(struct.atoms):
+                    if hasattr(atom, "frame"):
+                        dest.write(
+                            (intfmt * 2) % (2, i)
+                            + ("%4s%10.5f%14.5f%14.5f")
+                            % (
+                                "F",
+                                atom.frame.local_position[0],
+                                atom.frame.local_position[1],
+                                atom.frame.local_position[2],
+                            )
+                            + "\n"
+                        )
+                        idxs = [
+                            atom._idx + 1,
+                            atom.frame.atom1._idx + 1,
+                            atom.frame.atom2._idx + 1,
+                        ]
+                        for j in idxs:
+                            last_line += (intfmt) % (j)
+                            if i % 8 == 0:
+                                last_line += "\n"
+                            i += 1
+                dest.write(f"{last_line}\n")
+                dest.write("\n")
+            else:
+                dest.write((intfmt * 2) % (0, 0) + " !NUMLP NUMLPH \n")
+                dest.write("\n")
         # CMAP section
         dest.write(intfmt % len(struct.cmaps) + ' !NCRTERM: cross-terms\n')
         for i, cmap in enumerate(struct.cmaps):


### PR DESCRIPTION
Thanks for the support of LPs in ParmEd - that's really helpful!

As mentioned by @wiederm in https://github.com/ParmEd/ParmEd/pull/1157 there is still a problem when writing a psf file containing CHARMM LP (the lone pair section is always empty).

I needed this functionality so i tried to fix this. Although I am not a seasoned python coder I think I found the problem and I came up with an idea for a fix. If you are interested have a look at the code maybe it can help you!